### PR TITLE
DIT-2381 Add Upscan V2 initiate endpoint

### DIFF
--- a/app/uk/gov/hmrc/bindingtarifffilestore/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/audit/AuditService.scala
@@ -27,7 +27,7 @@ class AuditService @Inject()(auditConnector: DefaultAuditConnector) {
 
   import AuditPayloadType._
 
-  def auditUpScanInitiated(fileId: String, fileName: String, upScanRef: String)
+  def auditUpScanInitiated(fileId: String, fileName: Option[String], upScanRef: String)
                           (implicit hc: HeaderCarrier): Unit = {
     sendExplicitAuditEvent(
       auditEventType = UpScanInitiated,
@@ -35,7 +35,7 @@ class AuditService @Inject()(auditConnector: DefaultAuditConnector) {
     )
   }
 
-  def auditFileScanned(fileId: String, fileName: String, upScanRef: String, upScanStatus: String)
+  def auditFileScanned(fileId: String, fileName: Option[String], upScanRef: String, upScanStatus: String)
                       (implicit hc: HeaderCarrier): Unit = {
     sendExplicitAuditEvent(
       auditEventType = FileScanned,
@@ -58,6 +58,12 @@ class AuditService @Inject()(auditConnector: DefaultAuditConnector) {
     )
   }
 
+  private def fileDetailsAuditPayload(fileId: String, fileName: Option[String]): Map[String, String] = {
+    Map(
+      "fileId" -> fileId
+    ) ++ fileName.map(name => Map("fileName" -> name)).getOrElse(Map.empty)
+  }
+
   private def sendExplicitAuditEvent(auditEventType: String, auditPayload: Map[String, String])
                                     (implicit hc: HeaderCarrier): Unit = {
     auditConnector.sendExplicitAudit(auditType = auditEventType, detail = auditPayload)
@@ -66,7 +72,6 @@ class AuditService @Inject()(auditConnector: DefaultAuditConnector) {
 }
 
 object AuditPayloadType {
-
   val UpScanInitiated = "upScanInitiated"
   val FileScanned = "fileScanned"
   val FilePublished = "filePublished"

--- a/app/uk/gov/hmrc/bindingtarifffilestore/connector/AmazonS3Connector.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/connector/AmazonS3Connector.scala
@@ -68,7 +68,7 @@ class AmazonS3Connector @Inject()(config: AppConfig) {
     val url: URL = new URL(fileMetaData.url.getOrElse(throw new IllegalArgumentException("Missing URL")))
 
     val metadata = new ObjectMetadata
-    metadata.setContentType(fileMetaData.mimeType)
+    metadata.setContentType(fileMetaData.mimeType.get)
     metadata.setContentLength(contentLengthOf(url))
 
     val request = new PutObjectRequest(

--- a/app/uk/gov/hmrc/bindingtarifffilestore/connector/AmazonS3Connector.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/connector/AmazonS3Connector.scala
@@ -68,6 +68,8 @@ class AmazonS3Connector @Inject()(config: AppConfig) {
     val url: URL = new URL(fileMetaData.url.getOrElse(throw new IllegalArgumentException("Missing URL")))
 
     val metadata = new ObjectMetadata
+    // This .get is scary but our file must have received a positive scan
+    // result and received metadata from Upscan if it is being published
     metadata.setContentType(fileMetaData.mimeType.get)
     metadata.setContentLength(contentLengthOf(url))
 

--- a/app/uk/gov/hmrc/bindingtarifffilestore/connector/UpscanConnector.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/connector/UpscanConnector.scala
@@ -28,6 +28,7 @@ import play.api.Logger
 import uk.gov.hmrc.bindingtarifffilestore.config.AppConfig
 import uk.gov.hmrc.bindingtarifffilestore.model.FileWithMetadata
 import uk.gov.hmrc.bindingtarifffilestore.model.upscan.{UpscanTemplate, UploadSettings, UpscanInitiateResponse}
+import uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
@@ -42,6 +43,10 @@ class UpscanConnector @Inject()(appConfig: AppConfig, http: HttpClient)(
   def initiate(uploadSettings: UploadSettings)
               (implicit headerCarrier: HeaderCarrier): Future[UpscanInitiateResponse] = {
     http.POST[UploadSettings, UpscanInitiateResponse](s"${appConfig.upscanInitiateUrl}/upscan/initiate", uploadSettings)
+  }
+
+  def initiateV2(uploadRequest: v2.UpscanInitiateRequest)(implicit hc: HeaderCarrier): Future[v2.UpscanInitiateResponse] = {
+    http.POST[v2.UpscanInitiateRequest, v2.UpscanInitiateResponse](s"${appConfig.upscanInitiateUrl}/upscan/v2/initiate", uploadRequest)
   }
 
   def upload(template: UpscanTemplate, fileWithMetaData: FileWithMetadata): Future[Unit] = {

--- a/app/uk/gov/hmrc/bindingtarifffilestore/controllers/ErrorHandling.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/controllers/ErrorHandling.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.controllers
+
+import play.api.Logging
+import play.api.mvc.{ Action, AnyContent, BaseController, Request, Result }
+import reactivemongo.core.errors.DatabaseException
+import uk.gov.hmrc.bindingtarifffilestore.model.{ ErrorCode, JsErrorResponse }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait ErrorHandling { self: BaseController with Logging =>
+  private val DuplicateKeyError = 11000
+
+  private[controllers] def mongoErrorHandler: PartialFunction[Throwable, Result] = {
+    case e: DatabaseException if e.code.contains(DuplicateKeyError) =>
+      Conflict(JsErrorResponse(ErrorCode.CONFLICT, "Entity already exists"))
+    case e: Throwable =>
+      logger.error(s"An unexpected error occurred: ${e.getMessage}", e)
+      InternalServerError(JsErrorResponse(ErrorCode.UNKNOWN_ERROR, "An unexpected error occurred"))
+  }
+
+  def withErrorHandling(f: Request[AnyContent] => Future[Result])(implicit ec: ExecutionContext): Action[AnyContent] =
+    Action.async { request: Request[AnyContent] =>
+      f(request).recover(mongoErrorHandler)
+    }
+
+  def withErrorHandling[A](action: Action[A])(implicit ec: ExecutionContext): Action[A] =
+    Action(action.parser).async { request =>
+      action(request).recover(mongoErrorHandler)
+    }
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/controllers/FileStoreController.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/controllers/FileStoreController.scala
@@ -19,89 +19,124 @@ package uk.gov.hmrc.bindingtarifffilestore.controllers
 import java.util.UUID
 
 import javax.inject.{Inject, Singleton}
+import play.api.Logging
 import play.api.libs.Files.TemporaryFile
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.Json
 import play.api.mvc._
 import uk.gov.hmrc.bindingtarifffilestore.config.AppConfig
-import uk.gov.hmrc.bindingtarifffilestore.model.ErrorCode.NOTFOUND
 import uk.gov.hmrc.bindingtarifffilestore.model.FileMetadataREST._
 import uk.gov.hmrc.bindingtarifffilestore.model._
 import uk.gov.hmrc.bindingtarifffilestore.model.upscan.ScanResult
+import uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2._
 import uk.gov.hmrc.bindingtarifffilestore.service.FileStoreService
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.concurrent.Future.successful
+import scala.concurrent.{ ExecutionContext, Future }
+import play.api.libs.json.JsValue
 
 @Singleton
 class FileStoreController @Inject()(
-                                     appConfig: AppConfig,
-                                     service: FileStoreService,
-                                     parser: BodyParsers.Default,
-                                     mcc: MessagesControllerComponents
-                                   ) extends CommonController(mcc) {
+  appConfig: AppConfig,
+  service: FileStoreService,
+  parse: PlayBodyParsers,
+  mcc: MessagesControllerComponents
+)(implicit ec: ExecutionContext) extends BackendController(mcc) with ErrorHandling with JsonParsing with Logging {
 
-  lazy private val testModeFilter = TestMode.actionFilter(appConfig, parser)
+  private lazy val FileNotFound =
+    NotFound(JsErrorResponse(ErrorCode.NOTFOUND, "File Not Found"))
 
-  def deleteAll(): Action[AnyContent] = testModeFilter.async {
-    service.deleteAll() map (_ => NoContent) recover recovery
+  private def withFileMetadata(id: String)(f: FileMetadata => Future[Result]): Future[Result] =
+    service.find(id).flatMap {
+      case Some(meta) =>
+        f(meta)
+      case None =>
+        Future.successful(FileNotFound)
+    }
+
+  lazy private val testModeFilter = TestMode.actionFilter(appConfig, parse.default)
+
+  def deleteAll(): Action[AnyContent] = withErrorHandling {
+    testModeFilter.async {
+      service
+        .deleteAll()
+        .map(_ => NoContent)
+    }
   }
 
-  def delete(id: String): Action[AnyContent] = Action.async {
-    service.delete(id) map (_ => NoContent) recover recovery
+  def delete(id: String): Action[AnyContent] = withErrorHandling { _ =>
+    service
+      .delete(id)
+      .map(_ => NoContent)
   }
 
-  def upload: Action[AnyContent] = Action.async { implicit request: Request[AnyContent] =>
+  def initiate = withErrorHandling {
+    Action.async { implicit request =>
+      asJson[FileStoreInitiateRequest] { fileStoreRequest =>
+        service
+          .initiateV2(fileStoreRequest)
+          .map { response =>
+            Accepted(Json.toJson(response))
+          }
+      }
+    }
+  }
+
+  def upload: Action[AnyContent] = withErrorHandling { implicit request =>
     if (request.contentType.contains("application/json")) {
-      asJson[UploadRequest](initiate)
+      asJson[UploadRequest] { uploadRequest =>
+        service
+          .initiate(FileMetadata.fromUploadRequest(uploadRequest))
+          .map(template => Accepted(Json.toJson(template)))
+      }
     } else if (request.contentType.contains("multipart/form-data")) {
       request.body
         .asMultipartFormData.map(upload)
-        .getOrElse(successful(BadRequest))
+        .getOrElse(Future.successful(BadRequest))
     } else {
-      successful(BadRequest("Content-Type must be one of [application/json, multipart/form-data]"))
+      Future.successful(BadRequest("Content-Type must be one of [application/json, multipart/form-data]"))
     }
   }
 
   def get(id: String): Action[AnyContent] = Action.async {
-    handleNotFound(id, (att: FileMetadata) => successful(Ok(Json.toJson(att))))
-  }
-
-  def notification(id: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    withJsonBody[ScanResult] { scanResult =>
-      handleNotFound(id, (att: FileMetadata) => service.notify(att, scanResult).map(f => Created(Json.toJson(f)))) recover recovery
+    withFileMetadata(id) { meta =>
+      Future.successful(Ok(Json.toJson(meta)))
     }
   }
 
-  def publish(id: String): Action[AnyContent] = Action.async { implicit request =>
-    handleNotFound(id, (att: FileMetadata) =>
-      service.publish(att) map {
-        case Some(metadata) => Accepted(Json.toJson(metadata))
-        case None => NotFound(JsErrorResponse(NOTFOUND, "File Not Found"))
+  def notification(id: String): Action[JsValue] = withErrorHandling {
+    Action(parse.json).async { implicit req =>
+      withJsonBody[ScanResult] { scanResult =>
+        withFileMetadata(id) { meta =>
+          service
+            .notify(meta, scanResult)
+            .map { updatedMeta =>
+              Created(Json.toJson(updatedMeta))
+            }
+        }
       }
-    ) recover recovery
+    }
   }
 
-  def getAll(search: Search, pagination: Option[Pagination]): Action[AnyContent] = Action.async {
-    service.find(search, pagination.getOrElse(Pagination.max)) map { pagedResults =>
-      if(pagination.isDefined) {
+  def publish(id: String): Action[AnyContent] = withErrorHandling { implicit request =>
+    withFileMetadata(id) { meta =>
+      service.publish(meta).map {
+        case Some(updatedMeta) =>
+          Accepted(Json.toJson(updatedMeta))
+        case None =>
+          FileNotFound
+      }
+    }
+  }
+
+  def getAll(search: Search, pagination: Option[Pagination]): Action[AnyContent] = withErrorHandling { _ =>
+    service.find(search, pagination.getOrElse(Pagination.max)).map { pagedResults =>
+      if (pagination.isDefined) {
         Ok(Json.toJson(pagedResults))
       } else {
         Ok(Json.toJson(pagedResults.results))
       }
-    } recover recovery
-  }
-
-  private def initiate(template: UploadRequest)(implicit hc: HeaderCarrier): Future[Result] = {
-    service.initiate(
-      FileMetadata(
-        id = template.id.getOrElse(UUID.randomUUID().toString),
-        fileName = template.fileName,
-        mimeType = template.mimeType,
-        publishable = template.publishable
-      )
-    ).map(t => Accepted(Json.toJson(t))) recover recovery
+    }
   }
 
   private def upload(body: MultipartFormData[TemporaryFile])(implicit hc: HeaderCarrier): Future[Result] = {
@@ -114,8 +149,8 @@ class FileStoreController @Inject()(
         file.ref,
         FileMetadata(
           id = id,
-          fileName = file.filename,
-          mimeType = file.contentType.getOrElse(throw new RuntimeException("Missing file type")),
+          fileName = Some(file.filename),
+          mimeType = Some(file.contentType.getOrElse(throw new RuntimeException("Missing file type"))),
           publishable = publishable
         )
       )
@@ -123,14 +158,6 @@ class FileStoreController @Inject()(
 
     attachment
       .map(service.upload(_).map(f => Accepted(Json.toJson(f))))
-      .getOrElse(successful(BadRequest(JsErrorResponse(ErrorCode.INVALID_REQUEST_PAYLOAD, "Invalid File")))) recover recovery
+      .getOrElse(Future.successful(BadRequest(JsErrorResponse(ErrorCode.INVALID_REQUEST_PAYLOAD, "Invalid File"))))
   }
-
-  private def handleNotFound(id: String, result: FileMetadata => Future[Result]): Future[Result] = {
-    service.find(id) flatMap {
-      case Some(att: FileMetadata) => result(att)
-      case _ => successful(NotFound(JsErrorResponse(NOTFOUND, "File Not Found")))
-    }
-  }
-
 }

--- a/app/uk/gov/hmrc/bindingtarifffilestore/controllers/TestMode.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/controllers/TestMode.scala
@@ -23,14 +23,13 @@ import uk.gov.hmrc.bindingtarifffilestore.model.{ErrorCode, JsErrorResponse}
 import scala.concurrent.{ExecutionContext, Future}
 
 object TestMode {
-
-  def actionFilter(appConfig: AppConfig, bodyParser: BodyParsers.Default)(implicit ec: ExecutionContext) =
+  def actionFilter(appConfig: AppConfig, bodyParser: BodyParser[AnyContent])(implicit ec: ExecutionContext) =
     new ActionBuilder[Request, AnyContent] with ActionFilter[Request] {
 
-    override protected def filter[A](request: Request[A]): Future[Option[Result]] = Future.successful {
-      if (appConfig.isTestMode) None
-      else Some(Results.Forbidden(JsErrorResponse(ErrorCode.FORBIDDEN, s"You are not allowed to call ${request.method} ${request.uri}")))
-    }
+      override protected def filter[A](request: Request[A]): Future[Option[Result]] = Future.successful {
+        if (appConfig.isTestMode) None
+        else Some(Results.Forbidden(JsErrorResponse(ErrorCode.FORBIDDEN, s"You are not allowed to call ${request.method} ${request.uri}")))
+      }
 
       override def parser: BodyParser[AnyContent] = bodyParser
 

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/FileMetadata.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/FileMetadata.scala
@@ -17,15 +17,17 @@
 package uk.gov.hmrc.bindingtarifffilestore.model
 
 import java.time.{Instant, LocalDateTime, ZoneOffset}
-
+import java.{util => ju}
 import play.api.libs.json._
 import uk.gov.hmrc.bindingtarifffilestore.model.ScanStatus._
+import uk.gov.hmrc.bindingtarifffilestore.model.upscan._
+import uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
 
 case class FileMetadata
 (
   id: String,
-  fileName: String,
-  mimeType: String,
+  fileName: Option[String],
+  mimeType: Option[String],
   url: Option[String] = None,
   scanStatus: Option[ScanStatus] = None,
   publishable: Boolean = false,
@@ -62,6 +64,36 @@ case class FileMetadata
       }
     }
   }
+
+  def withScanResult(scanResult: ScanResult) = scanResult match {
+    case SuccessfulScanResult(reference, downloadUrl, uploadDetails) =>
+      copy(
+        fileName = Some(uploadDetails.fileName),
+        mimeType = Some(uploadDetails.fileMimeType),
+        url = Some(downloadUrl),
+        scanStatus = Some(ScanStatus.READY)
+      )
+    case FailedScanResult(reference, failureDetails) =>
+      copy(scanStatus = Some(ScanStatus.FAILED))
+  }
+}
+
+object FileMetadata {
+  def fromUploadRequest(uploadRequest: UploadRequest) =
+    FileMetadata(
+      id = uploadRequest.id.getOrElse(ju.UUID.randomUUID().toString),
+      fileName = Some(uploadRequest.fileName),
+      mimeType = Some(uploadRequest.mimeType),
+      publishable = uploadRequest.publishable
+    )
+
+  def fromInitiateRequestV2(id: String, request: v2.FileStoreInitiateRequest) =
+    FileMetadata(
+      id = id,
+      fileName = None,
+      mimeType = None,
+      publishable = request.publishable
+    )
 }
 
 object FileMetadataREST {
@@ -70,12 +102,12 @@ object FileMetadataREST {
       JsObject(
         Map[String, JsValue](
           "id" -> JsString(o.id),
-          "fileName" -> JsString(o.fileName),
-          "mimeType" -> JsString(o.mimeType),
           "publishable" -> JsBoolean(o.publishable),
           "published" -> JsBoolean(o.published),
           "lastUpdated" -> JsString(o.lastUpdated.toString)
         )
+          ++ o.fileName.map("fileName" -> Json.toJson(_))
+          ++ o.mimeType.map("mimeType" -> Json.toJson(_))
           ++ o.scanStatus.map("scanStatus" -> Json.toJson(_))
           ++ o.url.filter(_ => o.scanStatus.contains(READY)).map("url" -> JsString(_))
       )

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/ScanResult.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/ScanResult.scala
@@ -61,6 +61,8 @@ object ScanResult {
 
 case class UploadDetails
 (
+  fileName: String,
+  fileMimeType: String, 
   uploadTimestamp: Instant,
   checksum: String
 )

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
@@ -22,8 +22,6 @@ case class FileStoreInitiateRequest(
   id: Option[String] = None,
   successRedirect: Option[String] = None,
   errorRedirect: Option[String] = None,
-  minimumFileSize: Option[Long] = None,
-  maximumFileSize: Option[Long] = None,
   expectedContentType: Option[String] = None,
   publishable: Boolean = false
 )

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
+
+import play.api.libs.json.{ OFormat, Json }
+
+case class FileStoreInitiateRequest(
+  id: Option[String] = None,
+  successRedirect: Option[String] = None,
+  errorRedirect: Option[String] = None,
+  minimumFileSize: Option[Long] = None,
+  maximumFileSize: Option[Long] = None,
+  expectedContentType: Option[String] = None,
+  publishable: Boolean = false
+)
+
+object FileStoreInitiateRequest {
+  implicit val format: OFormat[FileStoreInitiateRequest] = Json.format[FileStoreInitiateRequest]
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateResponse.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateResponse.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
+
+import play.api.libs.json.{ OFormat, Json }
+
+case class FileStoreInitiateResponse(id: String, upscanReference: String, uploadRequest: UpscanFormTemplate)
+
+object FileStoreInitiateResponse {
+  implicit val format: OFormat[FileStoreInitiateResponse] = Json.format[FileStoreInitiateResponse]
+
+  def fromUpscanResponse(id: String, response: UpscanInitiateResponse) =
+    FileStoreInitiateResponse(
+      id = id,
+      upscanReference = response.reference,
+      uploadRequest = response.uploadRequest
+    )
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanFormTemplate.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanFormTemplate.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
+
+import play.api.libs.json.{ OFormat, Json }
+
+case class UpscanFormTemplate(href: String, fields: Map[String, String])
+
+object UpscanFormTemplate {
+  implicit val format: OFormat[UpscanFormTemplate] = Json.format[UpscanFormTemplate]
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
+
+import play.api.libs.json.{ OFormat, Json }
+
+case class UpscanInitiateRequest(
+  callbackUrl: String,
+  successRedirect: Option[String],
+  errorRedirect: Option[String],
+  minimumFileSize: Option[Long],
+  maximumFileSize: Option[Long],
+  expectedContentType: Option[String]
+)
+
+object UpscanInitiateRequest {
+  implicit val format: OFormat[UpscanInitiateRequest] = Json.format[UpscanInitiateRequest]
+
+  def fromFileStoreRequest(callbackUrl: String, request: FileStoreInitiateRequest) =
+    UpscanInitiateRequest(
+      callbackUrl = callbackUrl,
+      successRedirect = request.successRedirect,
+      errorRedirect = request.errorRedirect,
+      minimumFileSize = request.minimumFileSize,
+      maximumFileSize = request.maximumFileSize,
+      expectedContentType = request.expectedContentType
+    )
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
 
 import play.api.libs.json.{ OFormat, Json }
+import uk.gov.hmrc.bindingtarifffilestore.config.AppConfig
 
 case class UpscanInitiateRequest(
   callbackUrl: String,
@@ -30,13 +31,13 @@ case class UpscanInitiateRequest(
 object UpscanInitiateRequest {
   implicit val format: OFormat[UpscanInitiateRequest] = Json.format[UpscanInitiateRequest]
 
-  def fromFileStoreRequest(callbackUrl: String, request: FileStoreInitiateRequest) =
+  def fromFileStoreRequest(callbackUrl: String, appConfig: AppConfig, request: FileStoreInitiateRequest) =
     UpscanInitiateRequest(
       callbackUrl = callbackUrl,
       successRedirect = request.successRedirect,
       errorRedirect = request.errorRedirect,
-      minimumFileSize = request.minimumFileSize,
-      maximumFileSize = request.maximumFileSize,
+      minimumFileSize = Some(appConfig.fileStoreSizeConfiguration.minFileSize),
+      maximumFileSize = Some(appConfig.fileStoreSizeConfiguration.maxFileSize),
       expectedContentType = request.expectedContentType
     )
 }

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateResponse.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
+
+import play.api.libs.json.{ OFormat, Json }
+
+case class UpscanInitiateResponse(reference: String, uploadRequest: UpscanFormTemplate)
+
+object UpscanInitiateResponse {
+  implicit val format: OFormat[UpscanInitiateResponse] = Json.format[UpscanInitiateResponse]
+}

--- a/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
@@ -65,7 +65,7 @@ class FileStoreService @Inject()(appConfig: AppConfig,
         .absoluteURL(appConfig.filestoreSSL, appConfig.filestoreUrl) + s"?X-Api-Token=$authToken"
 
     val fileMetadata = FileMetadata.fromInitiateRequestV2(fileId, request)
-    val upscanRequest = v2.UpscanInitiateRequest.fromFileStoreRequest(callbackUrl, request)
+    val upscanRequest = v2.UpscanInitiateRequest.fromFileStoreRequest(callbackUrl, appConfig, request)
 
     for {
       update <- repository.insertFile(fileMetadata)

--- a/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.bindingtarifffilestore.service
 
+import java.{util => ju}
 import javax.inject.{Inject, Singleton}
-import play.api.Logger
+import play.api.Logging
 import uk.gov.hmrc.bindingtarifffilestore.audit.AuditService
 import uk.gov.hmrc.bindingtarifffilestore.config.AppConfig
 import uk.gov.hmrc.bindingtarifffilestore.connector.{AmazonS3Connector, UpscanConnector}
@@ -25,19 +26,20 @@ import uk.gov.hmrc.bindingtarifffilestore.controllers.routes
 import uk.gov.hmrc.bindingtarifffilestore.model.ScanStatus.{FAILED, READY}
 import uk.gov.hmrc.bindingtarifffilestore.model._
 import uk.gov.hmrc.bindingtarifffilestore.model.upscan._
+import uk.gov.hmrc.bindingtarifffilestore.model.upscan.v2
 import uk.gov.hmrc.bindingtarifffilestore.repository.FileMetadataMongoRepository
 import uk.gov.hmrc.bindingtarifffilestore.util.HashUtil
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton()
 class FileStoreService @Inject()(appConfig: AppConfig,
-                                 fileStoreConnector: AmazonS3Connector,
-                                 repository: FileMetadataMongoRepository,
-                                 upscanConnector: UpscanConnector,
-                                 auditService: AuditService) {
+  fileStoreConnector: AmazonS3Connector,
+  repository: FileMetadataMongoRepository,
+  upscanConnector: UpscanConnector,
+  auditService: AuditService
+)(implicit ec: ExecutionContext) extends Logging {
 
   private lazy val authToken = HashUtil.hash(appConfig.authorization)
 
@@ -51,6 +53,26 @@ class FileStoreService @Inject()(appConfig: AppConfig,
       initiateResponse <- upscanInitiate(metadata)
       template = initiateResponse.uploadRequest
     } yield UploadTemplate(fileId, template.href, template.fields)
+  }
+
+  def initiateV2(request: v2.FileStoreInitiateRequest)(implicit hc: HeaderCarrier): Future[v2.FileStoreInitiateResponse] = {
+    val fileId = request.id.getOrElse(ju.UUID.randomUUID().toString())
+
+    log(fileId, "Initiating")
+
+    val callbackUrl = routes.FileStoreController
+        .notification(fileId)
+        .absoluteURL(appConfig.filestoreSSL, appConfig.filestoreUrl) + s"?X-Api-Token=$authToken"
+
+    val fileMetadata = FileMetadata.fromInitiateRequestV2(fileId, request)
+    val upscanRequest = v2.UpscanInitiateRequest.fromFileStoreRequest(callbackUrl, request)
+
+    for {
+      update <- repository.insertFile(fileMetadata)
+      initiateResponse <- upscanConnector.initiateV2(upscanRequest)
+      _ = log(fileId, s"Upscan Initiated with url [${initiateResponse.uploadRequest.href}] and Upscan reference [${initiateResponse.reference}]")
+      _ = auditService.auditUpScanInitiated(update.id, update.fileName, initiateResponse.reference)
+    } yield v2.FileStoreInitiateResponse.fromUpscanResponse(fileId, initiateResponse)
   }
 
   // Initiates an upload and Uploads the file direct
@@ -85,26 +107,27 @@ class FileStoreService @Inject()(appConfig: AppConfig,
   def notify(attachment: FileMetadata, scanResult: ScanResult)(implicit hc: HeaderCarrier): Future[Option[FileMetadata]] = {
     log(attachment.id, s"Scan completed with status [${scanResult.fileStatus}] and Upscan reference [${scanResult.reference}]")
     auditService.auditFileScanned(attachment.id, attachment.fileName, scanResult.reference, scanResult.fileStatus.toString)
-    scanResult.fileStatus match {
-      case FAILED =>
-        val details = scanResult.asInstanceOf[FailedScanResult].failureDetails
+
+    val updatedAttachment = attachment.withScanResult(scanResult)
+
+    scanResult match {
+      case FailedScanResult(_, details) =>
         log(attachment.id, s"Scan failed because it was [${details.failureReason}] with message [${details.message}]")
-        repository.update(attachment.copy(scanStatus = Some(FAILED)))
-      case READY =>
-        val result = scanResult.asInstanceOf[SuccessfulScanResult]
-        val update = attachment.copy(url = Some(result.downloadUrl), scanStatus = Some(READY))
-        if (update.publishable) {
+        repository.update(updatedAttachment)
+      case SuccessfulScanResult(_, _, _) =>
+        if (updatedAttachment.publishable) {
           for {
-            updated: Option[FileMetadata] <- repository.update(update)
+            updated: Option[FileMetadata] <- repository.update(updatedAttachment)
             published: Option[FileMetadata] <- updated match {
-              case Some(metadata) => publish(metadata)
+              case Some(metadata) =>
+                publish(metadata)
               case _ =>
-                log(attachment.id, s"Scan completed as READY but it couldn't be published as it no longer exits")
+                log(attachment.id, s"Scan completed as READY but it couldn't be published as it no longer exists")
                 Future.successful(None)
             }
           } yield published
         } else {
-          repository.update(update)
+          repository.update(updatedAttachment)
         }
     }
   }
@@ -118,7 +141,7 @@ class FileStoreService @Inject()(appConfig: AppConfig,
       case (Some(READY), false) if att.isLive =>
         log(att.id, "Publishing file to Permanent Storage")
         val metadata = fileStoreConnector.upload(att)
-        auditService.auditFilePublished(att.id, att.fileName)
+        auditService.auditFilePublished(att.id, att.fileName.get)
         log(att.id, "Published file to Permanent Storage")
         repository.update(metadata.copy(publishable = true, published = true))
           .map(signingPermanentURL)
@@ -174,11 +197,11 @@ class FileStoreService @Inject()(appConfig: AppConfig,
   }
 
   private def error(id: String, message: String, error: Throwable): Unit = {
-    Logger.error(s"File [$id]: $message", error)
+    logger.error(s"File [$id]: $message", error)
   }
 
   private def log(id: String, message: String): Unit = {
-    Logger.info(s"File [$id]: $message")
+    logger.info(s"File [$id]: $message")
   }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,7 @@ GET        /file                    @uk.gov.hmrc.bindingtarifffilestore.controll
 GET        /file/:id                @uk.gov.hmrc.bindingtarifffilestore.controllers.FileStoreController.get(id: String)
 
 POST       /file                    @uk.gov.hmrc.bindingtarifffilestore.controllers.FileStoreController.upload
+POST       /file/initiate           @uk.gov.hmrc.bindingtarifffilestore.controllers.FileStoreController.initiate
 POST       /file/:id/notify         @uk.gov.hmrc.bindingtarifffilestore.controllers.FileStoreController.notification(id: String)
 POST       /file/:id/publish        @uk.gov.hmrc.bindingtarifffilestore.controllers.FileStoreController.publish(id: String)
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,35 +3,34 @@ import play.core.PlayVersion.current
 
 object AppDependencies {
 
-  private lazy val apacheHttpVersion = "4.5.8"
+  private lazy val apacheHttpVersion = "4.5.13"
 
   val compile = Seq(
-    "com.amazonaws"               %  "aws-java-sdk-s3"            % "1.11.532",
-    "uk.gov.hmrc"                 %% "bootstrap-play-26"          % "1.7.0",
-    "uk.gov.hmrc"                 %% "simple-reactivemongo"       % "7.30.0-play-26",
-    "uk.gov.hmrc"                 %% "play-json-union-formatter"  % "1.10.0-play-26",
+    "com.amazonaws"               %  "aws-java-sdk-s3"            % "1.11.882",
+    "uk.gov.hmrc"                 %% "bootstrap-backend-play-27"  % "2.25.0",
+    "uk.gov.hmrc"                 %% "simple-reactivemongo"       % "7.30.0-play-27",
+    "uk.gov.hmrc"                 %% "play-json-union-formatter"  % "1.12.0-play-27",
     "org.apache.httpcomponents"   %  "httpclient"                 % apacheHttpVersion,
     "org.apache.httpcomponents"   %  "httpmime"                   % apacheHttpVersion
   )
 
   val scope = "test, it"
 
-  val jettyVersion = "9.4.27.v20200227"
+  val jettyVersion = "9.4.32.v20200930"
 
   val test = Seq(
-    "com.github.tomakehurst"  %  "wiremock"                 % "2.26.3"        % scope,
-    "com.typesafe.play"       %% "play-test"                % current         % scope,
-    "org.mockito"             %  "mockito-core"             % "2.26.0"        % scope,
-    "org.jsoup"               %  "jsoup"                    % "1.11.3"        % scope,
-    "org.pegdown"             %  "pegdown"                  % "1.6.0"         % scope,
-    "org.scalatest"           %% "scalatest"                % "3.0.4"         % scope,
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "3.1.3"         % scope,
-    "org.scalacheck"          %% "scalacheck"               % "1.14.3"        % scope,
-    "uk.gov.hmrc"             %% "hmrctest"                 % "3.9.0-play-26" % scope,
-    "uk.gov.hmrc"             %% "http-verbs-test"          % "1.8.0-play-26" % scope,
-    "uk.gov.hmrc"             %% "service-integration-test" % "0.9.0-play-26" % scope,
-    "uk.gov.hmrc"             %% "reactivemongo-test"       % "4.21.0-play-26" % scope,
-    "org.scalaj"              %% "scalaj-http"            % "2.4.2"          % scope,
+    "com.github.tomakehurst"  %  "wiremock"                 % "2.27.2"         % scope,
+    "com.typesafe.play"       %% "play-test"                % current          % scope,
+    "org.mockito"             %  "mockito-core"             % "2.28.2"         % scope,
+    "org.jsoup"               %  "jsoup"                    % "1.13.1"         % scope,
+    "org.pegdown"             %  "pegdown"                  % "1.6.0"          % scope,
+    "org.scalatest"           %% "scalatest"                % "3.0.9"          % scope,
+    "org.scalatestplus.play"  %% "scalatestplus-play"       % "4.0.3"          % scope,
+    "org.scalacheck"          %% "scalacheck"               % "1.14.3"         % scope,
+    "uk.gov.hmrc"             %% "http-verbs-test"          % "1.8.0-play-27"  % scope,
+    "uk.gov.hmrc"             %% "service-integration-test" % "0.12.0-play-27" % scope,
+    "uk.gov.hmrc"             %% "reactivemongo-test"       % "4.21.0-play-27" % scope,
+    "org.scalaj"              %% "scalaj-http"              % "2.4.2"          % scope,
 
     //Need to peg this version for wiremock - try removing this on next lib upgrade
     "org.eclipse.jetty"       % "jetty-server"              % jettyVersion    % scope,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.11")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
@@ -11,3 +11,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")

--- a/test/it/uk/gov/hmrc/bindingtarifffilestore/AuthSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtarifffilestore/AuthSpec.scala
@@ -26,9 +26,8 @@ import uk.gov.hmrc.bindingtarifffilestore.util.{BaseFeatureSpec, ResourceFiles}
 
 class AuthSpec extends BaseFeatureSpec with ResourceFiles {
 
-  override lazy val port = 14682
-
   private val serviceUrl = s"http://localhost:$port"
+
   private val hashedTokenValue = BaseEncoding.base64Url().encode(
     MessageDigest.getInstance("SHA-256")
       .digest(appConfig.authorization.getBytes("UTF-8"))

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/audit/AuditServiceTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/audit/AuditServiceTest.scala
@@ -21,9 +21,9 @@ import org.mockito.Mockito.{reset, verify}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.bindingtarifffilestore.audit.AuditPayloadType._
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.audit.DefaultAuditConnector
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -47,7 +47,7 @@ class AuditServiceTest extends UnitSpec with MockitoSugar with BeforeAndAfterEac
   "auditUpScanInitiated()" should {
 
     "send the expected payload to the audit connector" in {
-      service.auditUpScanInitiated(fileId, fileName, upScanRef)
+      service.auditUpScanInitiated(fileId, Some(fileName), upScanRef)
 
       val payload = auditPayload(fileId, fileName) + ("upScanReference" -> upScanRef)
 
@@ -58,7 +58,7 @@ class AuditServiceTest extends UnitSpec with MockitoSugar with BeforeAndAfterEac
   "auditFileScanned()" should {
 
     "send the expected payload to the audit connector" in {
-      service.auditFileScanned(fileId, fileName, upScanRef, upScanStatus)
+      service.auditFileScanned(fileId, Some(fileName), upScanRef, upScanStatus)
 
       val payload = auditPayload(fileId, fileName) + ("upScanReference" -> upScanRef, "upScanStatus" -> upScanStatus)
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/config/AppConfigSpec.scala
@@ -22,8 +22,8 @@ import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
+import uk.gov.hmrc.bindingtarifffilestore.util.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class AppConfigSpec extends UnitSpec with WithFakeApplication with MockitoSugar with BeforeAndAfterEach {
   val serviceConfig: ServicesConfig = mock[ServicesConfig]

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/connector/UpscanConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/connector/UpscanConnectorSpec.scala
@@ -27,11 +27,10 @@ import play.api.libs.ws.WSClient
 import uk.gov.hmrc.bindingtarifffilestore.config.AppConfig
 import uk.gov.hmrc.bindingtarifffilestore.model.upscan.{UploadSettings, UpscanInitiateResponse, UpscanTemplate}
 import uk.gov.hmrc.bindingtarifffilestore.model.{FileMetadata, FileWithMetadata}
-import uk.gov.hmrc.bindingtarifffilestore.util.{ResourceFiles, WiremockTestServer}
+import uk.gov.hmrc.bindingtarifffilestore.util._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.HttpAuditing
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -93,7 +92,7 @@ class UpscanConnectorSpec extends UnitSpec with WithFakeApplication with Wiremoc
       )
       val fileUploading = FileWithMetadata(
         SingletonTemporaryFileCreator.create("example-file.json"),
-        FileMetadata("id", "file.txt", "text/plain")
+        FileMetadata("id", Some("file.txt"), Some("text/plain"))
       )
 
       await(connector.upload(templateUploading, fileUploading))
@@ -117,7 +116,7 @@ class UpscanConnectorSpec extends UnitSpec with WithFakeApplication with Wiremoc
       )
       val fileUploading = FileWithMetadata(
         SingletonTemporaryFileCreator.create("example-file.json"),
-        FileMetadata("id", "file.txt", "text/plain")
+        FileMetadata("id", Some("file.txt"), Some("text/plain"))
       )
 
       intercept[RuntimeException] {

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/FileMetadataSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/FileMetadataSpec.scala
@@ -17,9 +17,8 @@
 package uk.gov.hmrc.bindingtarifffilestore.model
 
 import java.time.Instant
-
 import play.api.libs.json._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class FileMetadataSpec extends UnitSpec {
 
@@ -27,8 +26,8 @@ class FileMetadataSpec extends UnitSpec {
 
     val model = FileMetadata(
       id = "id",
-      fileName = "fileName",
-      mimeType = "type",
+      fileName = Some("fileName"),
+      mimeType = Some("type"),
       url = Some("url"),
       publishable = true,
       published = true,
@@ -118,13 +117,13 @@ class FileMetadataSpec extends UnitSpec {
     }
 
     "Calculate liveness of signed URL" in {
-      def metadata(url: String): FileMetadata = FileMetadata("id", "file", "type", Some(url))
+      def metadata(url: String): FileMetadata = FileMetadata("id", Some("file"), Some("type"), Some(url))
 
       metadata("https://s3.amazonaws.com/bucket/abc?X-Amz-Date=30000101T000000Zkey=value&X-Amz-Expires=86400").isLive shouldBe true
       metadata("https://s3.amazonaws.com/bucket/abc?X-Amz-Expires=86400&X-Amz-Date=30000101T000000Zkey=value").isLive shouldBe true
       metadata("https://s3.amazonaws.com/bucket/file?X-Amz-Date=20190101T000000Z&X-Amz-Expires=0").isLive shouldBe false
       metadata("url").isLive shouldBe true
-      FileMetadata("id", "file", "type").isLive shouldBe true
+      FileMetadata("id", Some("file"), Some("type")).isLive shouldBe true
     }
 
   }

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/PagedTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/PagedTest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.bindingtarifffilestore.model
 
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class PagedTest extends UnitSpec {
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/PaginationTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/PaginationTest.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.bindingtarifffilestore.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class PaginationTest extends UnitSpec {
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/SearchTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/SearchTest.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.bindingtarifffilestore.model
 
 import java.net.URLDecoder
-
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class SearchTest extends UnitSpec {
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/UploadRequestSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/UploadRequestSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.bindingtarifffilestore.model
 
 import play.api.libs.json.Json
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class UploadRequestSpec extends UnitSpec {
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/upscan/ScanResultSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/model/upscan/ScanResultSpec.scala
@@ -19,16 +19,18 @@ package uk.gov.hmrc.bindingtarifffilestore.model.upscan
 import java.time.Instant
 
 import play.api.libs.json.{JsObject, JsString, Json}
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 class ScanResultSpec extends UnitSpec {
 
   "Successful Scan Result" should {
-    val model = SuccessfulScanResult("ref", "url", UploadDetails(Instant.EPOCH, "checksum"))
+    val model = SuccessfulScanResult("ref", "url", UploadDetails("file", "type", Instant.EPOCH, "checksum"))
     val json = JsObject(Map(
       "reference" -> JsString("ref"),
       "downloadUrl" -> JsString("url"),
       "uploadDetails" -> JsObject(Map(
+        "fileName" -> JsString("file"),
+        "fileMimeType" -> JsString("type"),
         "uploadTimestamp" -> JsString("1970-01-01T00:00:00Z"),
         "checksum" -> JsString("checksum")
       )),

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/repository/BaseMongoIndexSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/repository/BaseMongoIndexSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.bindingtarifffilestore.repository
 
 import reactivemongo.api.indexes.Index
 import reactivemongo.play.json.collection.JSONCollection
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/repository/FileMetadataRepositorySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/repository/FileMetadataRepositorySpec.scala
@@ -104,7 +104,7 @@ class FileMetadataRepositorySpec extends BaseMongoIndexSpec
       await(repository.insertFile(att1))
       val size = collectionSize
 
-      val updated = att1.copy(mimeType = generateString, fileName = generateString)
+      val updated = att1.copy(mimeType = Some(generateString), fileName = Some(generateString))
       await(repository.update(updated))
       collectionSize shouldBe size
 
@@ -225,8 +225,8 @@ class FileMetadataRepositorySpec extends BaseMongoIndexSpec
 
   private def generateAttachment = FileMetadata(
     id = generateString,
-    fileName = generateString,
-    mimeType = generateString
+    fileName = Some(generateString),
+    mimeType = Some(generateString)
   )
 
   private def generateString = UUID.randomUUID().toString

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreServiceSpec.scala
@@ -30,8 +30,8 @@ import uk.gov.hmrc.bindingtarifffilestore.connector.{AmazonS3Connector, UpscanCo
 import uk.gov.hmrc.bindingtarifffilestore.model._
 import uk.gov.hmrc.bindingtarifffilestore.model.upscan._
 import uk.gov.hmrc.bindingtarifffilestore.repository.FileMetadataMongoRepository
+import uk.gov.hmrc.bindingtarifffilestore.util.UnitSpec
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future.successful
@@ -149,7 +149,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
   "Service 'initiate'" should {
 
     "Delegate to Connector" in {
-      val fileMetadata = FileMetadata(id = "id", fileName = "file", mimeType = "text/plain")
+      val fileMetadata = FileMetadata(id = "id", fileName = Some("file"), mimeType = Some("text/plain"))
       val fileMetaDataCreated = mock[FileMetadata]
       val uploadTemplate = UpscanTemplate(href = "href", fields = Map("key" -> "value"))
       val initiateResponse = UpscanInitiateResponse("ref", uploadTemplate)
@@ -162,7 +162,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
       await(service.initiate(fileMetadata)) shouldBe UploadTemplate(id = "id", href = "href", fields = Map("key" -> "value"))
 
-      verify(auditService, times(1)).auditUpScanInitiated(fileId = "id", fileName = "file", upScanRef = "ref")
+      verify(auditService, times(1)).auditUpScanInitiated(fileId = "id", fileName = Some("file"), upScanRef = "ref")
       verifyNoMoreInteractions(auditService)
 
       theInitatePayload shouldBe UploadSettings(
@@ -177,7 +177,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
     "Delegate to Connector" in {
       val file = mock[TemporaryFile]
-      val fileMetadata = FileMetadata(id = "id", fileName = "file", mimeType = "text/plain")
+      val fileMetadata = FileMetadata(id = "id", fileName = Some("file"), mimeType = Some("text/plain"))
       val fileWithMetadata = FileWithMetadata(file, fileMetadata)
       val fileMetaDataCreated = mock[FileMetadata]
       val uploadTemplate = mock[UpscanTemplate]
@@ -192,7 +192,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
       await(service.upload(fileWithMetadata)) shouldBe fileMetaDataCreated
 
-      verify(auditService, times(1)).auditUpScanInitiated(fileId = "id", fileName = "file", upScanRef = "ref")
+      verify(auditService, times(1)).auditUpScanInitiated(fileId = "id", fileName = Some("file"), upScanRef = "ref")
       verifyNoMoreInteractions(auditService)
 
       theInitatePayload shouldBe UploadSettings(
@@ -212,16 +212,19 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
   "Service 'notify' " should {
 
     "Update the attachment for Successful Scan and Delegate to Connector" in {
-      val attachment = FileMetadata(id = "id", fileName = "file", mimeType = "type")
+      val attachment = FileMetadata(id = "id", fileName = Some("file"), mimeType = Some("type"))
       val attachmentUpdated = mock[FileMetadata]("updated")
-      val scanResult = SuccessfulScanResult("ref", "url", mock[UploadDetails])
+      val uploadDetails = mock[UploadDetails]
+      val scanResult = SuccessfulScanResult("ref", "url", uploadDetails)
       val expectedAttachment = attachment.copy(url = Some("url"), scanStatus = Some(ScanStatus.READY))
 
+      given(uploadDetails.fileName).willReturn("file")
+      given(uploadDetails.fileMimeType).willReturn("type")
       given(repository.update(expectedAttachment)).willReturn(successful(Some(attachmentUpdated)))
 
       await(service.notify(attachment, scanResult)) shouldBe Some(attachmentUpdated)
 
-      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = "file", upScanRef = "ref", upScanStatus = "READY")
+      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = Some("file"), upScanRef = "ref", upScanStatus = "READY")
       verifyNoMoreInteractions(auditService)
     }
 
@@ -235,12 +238,12 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       val attachmentUploadedUpdated = mock[FileMetadata]("AttachmentUploadedAndUpdated")
       val attachmentSigned = mock[FileMetadata]("AttachmentSigned")
 
-      given(attachment.copy(scanStatus = Some(ScanStatus.READY), url = Some("url"))).willReturn(attachmentUpdating)
+      given(attachment.withScanResult(scanResult)).willReturn(attachmentUpdating)
       given(attachment.publishable).willReturn(true)
       given(attachment.published).willReturn(false)
       given(attachment.isLive).willReturn(true)
       given(attachment.id).willReturn("id")
-      given(attachment.fileName).willReturn("file")
+      given(attachment.fileName).willReturn(Some("file"))
 
       given(attachmentUpdating.publishable).willReturn(true)
       given(attachmentUpdating.published).willReturn(false)
@@ -251,7 +254,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       given(attachmentUpdated.isLive).willReturn(true)
       given(attachmentUpdated.scanStatus).willReturn(Some(ScanStatus.READY))
       given(attachmentUpdated.id).willReturn("id")
-      given(attachmentUpdated.fileName).willReturn("file")
+      given(attachmentUpdated.fileName).willReturn(Some("file"))
 
       given(attachmentUploaded.published).willReturn(true)
       given(attachmentUploaded.publishable).willReturn(true)
@@ -268,28 +271,29 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
       await(service.notify(attachment, scanResult)) shouldBe Some(attachmentSigned)
 
-      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = "file", upScanRef = "ref", upScanStatus = "READY")
+      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = Some("file"), upScanRef = "ref", upScanStatus = "READY")
       verify(auditService, times(1)).auditFilePublished(fileId = "id", fileName = "file")
       verifyNoMoreInteractions(auditService)
     }
 
     "Skip publishing when the file no longer exists" in {
       val attachment = mock[FileMetadata]("Attachment")
-      val scanResult = SuccessfulScanResult("ref", "url", mock[UploadDetails])
+      val uploadDetails = mock[UploadDetails]
+      val scanResult = SuccessfulScanResult("ref", "url", uploadDetails)
       val attachmentUpdating = mock[FileMetadata]("AttachmentUpdating")
       val attachmentUpdated = mock[FileMetadata]("AttachmentUpdated")
 
-      given(attachment.copy(scanStatus = Some(ScanStatus.READY), url = Some("url"))).willReturn(attachmentUpdating)
+      given(attachment.withScanResult(scanResult)).willReturn(attachmentUpdating)
       given(attachment.publishable).willReturn(true)
       given(attachment.id).willReturn("id")
-      given(attachment.fileName).willReturn("file")
+      given(attachment.fileName).willReturn(Some("file"))
 
       given(attachmentUpdating.published).willReturn(true)
 
       given(attachmentUpdated.published).willReturn(true)
       given(attachmentUpdated.scanStatus).willReturn(Some(ScanStatus.READY))
       given(attachmentUpdated.id).willReturn("id")
-      given(attachmentUpdated.fileName).willReturn("file")
+      given(attachmentUpdated.fileName).willReturn(Some("file"))
 
       given(repository.update(attachmentUpdating)).willReturn(successful(None))
 
@@ -297,13 +301,13 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
       verify(s3Connector, never()).upload(any[FileMetadata])
       verify(s3Connector, never()).sign(any[FileMetadata])
-      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = "file", upScanRef = "ref", upScanStatus = "READY")
+      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = Some("file"), upScanRef = "ref", upScanStatus = "READY")
       verify(auditService, never()).auditFilePublished(fileId = "id", fileName = "file")
       verifyNoMoreInteractions(auditService)
     }
 
     "Update the attachment for Failed Scan and Delegate to Connector" in {
-      val attachment = FileMetadata(id = "id", fileName = "file", mimeType = "type")
+      val attachment = FileMetadata(id = "id", fileName = Some("file"), mimeType = Some("type"))
       val scanResult = FailedScanResult("ref", mock[FailureDetails])
       val expectedAttachment = attachment.copy(scanStatus = Some(ScanStatus.FAILED))
       val attachmentUpdated = mock[FileMetadata]("updated")
@@ -312,7 +316,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
       await(service.notify(attachment, scanResult)) shouldBe Some(attachmentUpdated)
 
-      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = "file", upScanRef = "ref", upScanStatus = "FAILED")
+      verify(auditService, times(1)).auditFileScanned(fileId = "id", fileName = Some("file"), upScanRef = "ref", upScanStatus = "FAILED")
       verifyNoMoreInteractions(auditService)
     }
 
@@ -331,7 +335,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       given(fileUploading.published).willReturn(false)
       given(fileUploading.isLive).willReturn(true)
       given(fileUploading.id).willReturn("id")
-      given(fileUploading.fileName).willReturn("file")
+      given(fileUploading.fileName).willReturn(Some("file"))
 
       given(fileUploaded.copy(published = true)).willReturn(fileUpdating)
 

--- a/test/util/uk/gov/hmrc/bindingtarifffilestore/util/UnitSpec.scala
+++ b/test/util/uk/gov/hmrc/bindingtarifffilestore/util/UnitSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.util
+
+import java.nio.charset.Charset
+
+import akka.stream.Materializer
+import akka.util.ByteString
+import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.implicitConversions
+
+trait UnitSpec extends WordSpecLike with Matchers with OptionValues {
+
+  import scala.concurrent.duration._
+  import scala.concurrent.{Await, Future}
+
+  implicit val defaultTimeout: FiniteDuration = 5.seconds
+
+  implicit def extractAwait[A](future: Future[A]): A = await[A](future)
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A = Await.result(future, timeout)
+
+  // Convenience to avoid having to wrap andThen() parameters in Future.successful
+  implicit def liftFuture[A](v: A): Future[A] = Future.successful(v)
+
+  def status(of: Result): Int = of.header.status
+
+  def status(of: Future[Result])(implicit timeout: Duration): Int = status(Await.result(of, timeout))
+
+  def jsonBodyOf(result: Result)(implicit mat: Materializer): JsValue = {
+    Json.parse(bodyOf(result))
+  }
+
+  def jsonBodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[JsValue] = {
+    resultF.map(jsonBodyOf)
+  }
+
+  def bodyOf(result: Result)(implicit mat: Materializer): String = {
+    val bodyBytes: ByteString = await(result.body.consumeData)
+    // We use the default charset to preserve the behaviour of a previous
+    // version of this code, which used new String(Array[Byte]).
+    // If the fact that the previous version used the default charset was an
+    // accident then it may be better to decode in UTF-8 or the charset
+    // specified by the result's headers.
+    bodyBytes.decodeString(Charset.defaultCharset().name)
+  }
+
+  def bodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[String] = {
+    resultF.map(bodyOf)
+  }
+}

--- a/test/util/uk/gov/hmrc/bindingtarifffilestore/util/WiremockTestServer.scala
+++ b/test/util/uk/gov/hmrc/bindingtarifffilestore/util/WiremockTestServer.scala
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.{MappingBuilder, WireMock}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatest.BeforeAndAfterEach
-import uk.gov.hmrc.play.test.UnitSpec
 
 trait WiremockTestServer extends UnitSpec with BeforeAndAfterEach {
 

--- a/test/util/uk/gov/hmrc/bindingtarifffilestore/util/WithFakeApplication.scala
+++ b/test/util/uk/gov/hmrc/bindingtarifffilestore/util/WithFakeApplication.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.bindingtarifffilestore.util
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import play.api.{Application, Play}
+import play.api.test.Helpers._
+import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+
+/**
+ * Use this instead of play.test.WithApplication
+ *
+ * WithApplication will bring in specs2 lifecyles and changes the test run behaviour
+ */
+trait WithFakeApplication extends BeforeAndAfterAll {
+  this: Suite =>
+
+  lazy val fakeApplication: Application = new GuiceApplicationBuilder().bindings(bindModules:_*).build()
+
+  def bindModules: Seq[GuiceableModule] = Seq()
+
+  override def beforeAll() {
+    super.beforeAll()
+    Play.start(fakeApplication)
+  }
+
+  override def afterAll() {
+    super.afterAll()
+    Play.stop(fakeApplication)
+  }
+
+  def evaluateUsingPlay[T](block: => T): T = {
+    running(fakeApplication) {
+      block
+    }
+  }
+
+}


### PR DESCRIPTION
* Makes fileName and fileMimeType optional in the FileMetadata, since we won't know them if the file POST request doesn't come to us directly anymore
* Upgrade to Play 2.7
* Add new v2 Request & Response structures to match Upscan V2 endpoint
* Add new POST endpoint at /file/initiate which creates file metadata and calls Upscan initiate only

