### PR TITLE
Revert "DIT-2383 Add the callback URL into the filestore initiate request"

### DIFF
--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/FileStoreInitiateRequest.scala
@@ -20,7 +20,6 @@ import play.api.libs.json.{ OFormat, Json }
 
 case class FileStoreInitiateRequest(
   id: Option[String] = None,
-  callbackUrl: String,
   successRedirect: Option[String] = None,
   errorRedirect: Option[String] = None,
   expectedContentType: Option[String] = None,

--- a/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/model/upscan/v2/UpscanInitiateRequest.scala
@@ -31,9 +31,9 @@ case class UpscanInitiateRequest(
 object UpscanInitiateRequest {
   implicit val format: OFormat[UpscanInitiateRequest] = Json.format[UpscanInitiateRequest]
 
-  def fromFileStoreRequest(appConfig: AppConfig, request: FileStoreInitiateRequest) =
+  def fromFileStoreRequest(callbackUrl: String, appConfig: AppConfig, request: FileStoreInitiateRequest) =
     UpscanInitiateRequest(
-      callbackUrl = request.callbackUrl,
+      callbackUrl = callbackUrl,
       successRedirect = request.successRedirect,
       errorRedirect = request.errorRedirect,
       minimumFileSize = Some(appConfig.fileStoreSizeConfiguration.minFileSize),

--- a/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
+++ b/app/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreService.scala
@@ -60,8 +60,12 @@ class FileStoreService @Inject()(appConfig: AppConfig,
 
     log(fileId, "Initiating")
 
+    val callbackUrl = routes.FileStoreController
+        .notification(fileId)
+        .absoluteURL(appConfig.filestoreSSL, appConfig.filestoreUrl) + s"?X-Api-Token=$authToken"
+
     val fileMetadata = FileMetadata.fromInitiateRequestV2(fileId, request)
-    val upscanRequest = v2.UpscanInitiateRequest.fromFileStoreRequest(appConfig, request)
+    val upscanRequest = v2.UpscanInitiateRequest.fromFileStoreRequest(callbackUrl, appConfig, request)
 
     for {
       update <- repository.insertFile(fileMetadata)

--- a/test/it/uk/gov/hmrc/bindingtarifffilestore/FileStoreSpec.scala
+++ b/test/it/uk/gov/hmrc/bindingtarifffilestore/FileStoreSpec.scala
@@ -501,15 +501,10 @@ class FileStoreSpec extends WiremockFeatureTestServer with ResourceFiles {
   private def initiateV2(id: Option[String] = None): HttpResponse[Map[String, JsValue]] = {
     stubUpscanInitiateV2
 
-    val initiateRequest = v2.FileStoreInitiateRequest(
-      id = id,
-      callbackUrl = "http://localhost/notify"
-    )
-
     Http(s"$serviceUrl/file/initiate")
       .header("Content-Type", "application/json")
       .header(apiTokenKey, appConfig.authorization)
-      .postData(Json.toJson(initiateRequest).toString)
+      .postData(Json.toJson(v2.FileStoreInitiateRequest(id = id)).toString())
       .execute(convertingResponseToJS)
   }
 

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/controllers/FileStoreControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/controllers/FileStoreControllerSpec.scala
@@ -251,7 +251,7 @@ class FileStoreControllerSpec extends UnitSpec with Matchers
       when(service.initiateV2(any[FileStoreInitiateRequest])(any[HeaderCarrier])).thenReturn(successful(response))
 
       // When
-      val request = FileStoreInitiateRequest(callbackUrl = "http://localhost/notify", publishable = true)
+      val request = FileStoreInitiateRequest(publishable = true)
       val result: Result = await(controller.initiate(jsonRequest(request)))
 
       // Then
@@ -264,7 +264,7 @@ class FileStoreControllerSpec extends UnitSpec with Matchers
       when(service.initiateV2(any[FileStoreInitiateRequest])(any[HeaderCarrier])).thenReturn(successful(response))
 
       // When
-      val request = FileStoreInitiateRequest(id = Some("id"), callbackUrl = "http://localhost/notify", publishable = true)
+      val request = FileStoreInitiateRequest(id = Some("id"), publishable = true)
       val result: Result = await(controller.initiate(jsonRequest(request)))
 
       // Then

--- a/test/unit/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtarifffilestore/service/FileStoreServiceSpec.scala
@@ -175,7 +175,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
 
   "Service 'initiateV2'" should {
     "Delegate to Connector" in {
-      val initiateRequest = v2.FileStoreInitiateRequest(id = Some("id"), callbackUrl = "http://localhost/notify")
+      val initiateRequest = v2.FileStoreInitiateRequest(id = Some("id"))
       val fileMetadata = FileMetadata("id", None, None)
       val uploadTemplate = v2.UpscanFormTemplate(href = "href", fields = Map("key" -> "value"))
       val initiateResponse = v2.UpscanInitiateResponse("ref", uploadTemplate)
@@ -193,7 +193,7 @@ class FileStoreServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       verifyNoMoreInteractions(auditService)
 
       theInitiateV2Payload shouldBe v2.UpscanInitiateRequest(
-        callbackUrl = "http://localhost/notify",
+        callbackUrl = "http://host/file/id/notify?X-Api-Token=2yL0YYIInq0TGnTCyaUwQhXpxtIktdzWH7QIx9mmMWU=",
         successRedirect = None,
         errorRedirect = None,
         minimumFileSize = Some(1),


### PR DESCRIPTION
Reverts hmrc/binding-tariff-filestore#40

I spoke to @chotai and he explained that this is not such a problem after all as the platform would have to be compromised in order to make use of this API token

I prefer not to add the proxying of this notify endpoint if we don't need to so let's go back to the previous version of this